### PR TITLE
Generate command fails with SUITE files in ebin

### DIFF
--- a/test.config
+++ b/test.config
@@ -7,7 +7,6 @@
 {erl_opts, [
     debug_info,
     fail_on_warning,
-    {src_dirs, ["test"]},
     {platform_define, "^[0-9]+", namespaced_types}
     ]}.
 


### PR DESCRIPTION
rebar ct compiles the files in `test` anyway, the erl_opts src_dir
property looks superflous to me. With it removed tests run (and pass)
and generate works.